### PR TITLE
Made the test runnable

### DIFF
--- a/tests/views/template_test.php
+++ b/tests/views/template_test.php
@@ -24,7 +24,7 @@
  * @package MvcTemplateTiein
  * @subpackage Tests
  */
-require_once 'MvcTemplateTiein/tests/testfiles/testclasses.php';
+require_once __DIR__ . '/../testfiles/testclasses.php';
 
 /**
  * Test the handler classes.


### PR DESCRIPTION
Fixed the naming of the test-file and added the needed suffix `_test.php` as required by phpunit configuration in `phpunit.xml.dist`.
Also changed the path of the `require_once`-statement to work from several working-directories when running phpunit.