### PR TITLE
Define two class properties.

### DIFF
--- a/src/viewhandlers/template.php
+++ b/src/viewhandlers/template.php
@@ -55,6 +55,16 @@ class ezcMvcTemplateViewHandler implements ezcMvcViewHandler
     protected $variables = array();
 
     /**
+     * @var string
+     */
+    protected $templateLocation;
+
+    /**
+     * @var ezcTemplate
+     */
+    protected $template;
+
+    /**
      * Creates a new view handler, where $zoneName is the name of the block and
      * $templateLocation the location of a view template.
      *


### PR DESCRIPTION
On PHP 8.2 this component throws an `ErrorException`:

```
Creation of dynamic property ezcMvcTemplateViewHandler::$templateLocation is deprecated
```